### PR TITLE
chore: connect PostgreSQL;

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+	runtimeOnly 'org.postgresql:postgresql'
+	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,9 @@
 spring.application.name=its
 spring.thymeleaf.prefix=file:src/main/resources/templates/
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://localhost:5432/its
+spring.datasource.username=springuser
+spring.datasource.password=springuser
+spring.sql.init.mode=always
+logging.level.com.example.its.repository=DEBUG
+spring.datasource.sql-script-encoding=UTF-8

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,3 @@
+insert into issues (summary, description) values ('バグA', 'バグがあります');
+insert into issues (summary, description) values ('機能要望B', 'Bに追加機能がほしいです');
+insert into issues (summary, description) values ('画面Cが遅い', '速くしてほしいです');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS issues;
+
+create table issues (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    summary VARCHAR(256) NOT NULL,
+    description VARCHAR(256) NOT NULL
+);


### PR DESCRIPTION
### 🛠 やったこと
- PostgreSQL に接続するための設定を `application.properties` に追加
- DB初期化用の `schema.sql` と `data.sql` を作成
- `build.gradle` に PostgreSQL および MyBatis の依存関係を追加

### 🧠 背景・目的
- アプリケーション起動時に PostgreSQL に接続し、テーブル作成と初期データ投入を行うため
- 永続的なデータ保存と開発効率向上を目的として導入

### ✅ 確認方法
- アプリケーション起動時にエラーが出ないことを確認
- `issues` テーブルが作成され、3件の初期データが投入されていることを確認

### 💬 補足・メモ（あれば）
- PostgreSQL のローカル起動と `its` データベースの事前作成が必要
- 今後、接続先や資格情報は `.env` 等で外部管理予定
