### PR TITLE
feat: Viewから来たデータをDBに保存

### DIFF
--- a/src/main/java/com/example/its/domain/issue/IssueRepository.java
+++ b/src/main/java/com/example/its/domain/issue/IssueRepository.java
@@ -1,0 +1,17 @@
+package com.example.its.domain.issue;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface IssueRepository {
+
+    @Select("select * from issues")
+    List<IssueEntity> findAll();
+
+    @Insert("insert into issues (summary, description) values (#{summary}, #{description})")
+    void insert(String summary, String description);
+}

--- a/src/main/java/com/example/its/domain/issue/IssueService.java
+++ b/src/main/java/com/example/its/domain/issue/IssueService.java
@@ -1,15 +1,21 @@
 package com.example.its.domain.issue;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class IssueService {
+
+    private final IssueRepository issueRepository;
+
     public List<IssueEntity> findAll() {
-        return List.of(
-                new IssueEntity(1, "概要1", "説明1"),
-                new IssueEntity(2, "概要2", "説明2"),
-                new IssueEntity(3, "概要3", "説明3")
-        );
+        return issueRepository.findAll();
+    }
+
+    // TODO トランザクション
+    public void create(String summary, String description) {
+        issueRepository.insert(summary, description);
     }
 }

--- a/src/main/java/com/example/its/web/issue/IssueController.java
+++ b/src/main/java/com/example/its/web/issue/IssueController.java
@@ -5,13 +5,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@RequestMapping("/issues")
 @RequiredArgsConstructor //finalが付いたフィールドを引数とするコンストラクタを自動生成するアノテ
 public class IssueController {
     private final IssueService issueService;
 
-    @GetMapping("/issues")
+    @GetMapping
     public String showList(Model model) {
 
         model.addAttribute("issueList", issueService.findAll());
@@ -19,5 +23,17 @@ public class IssueController {
         //↓この行にBPはってデバッグし、右クリ→式の評価→model、でmodelに値がちゃんと入ってるのが確認できる。
         // てことはviewに値を渡す準備できてるってこと。
         return "issues/List";
+    }
+
+    @GetMapping("/creationForm")
+    public String showCreationForm(@ModelAttribute IssueForm form) {
+        return "issues/creationForm";
+    }
+
+    @PostMapping
+    public String create(IssueForm form, Model model) {
+
+        issueService.create(form.getSummary(), form.getDescription());
+        return showList(model); //TODO リロードボタン対策が必要
     }
 }

--- a/src/main/java/com/example/its/web/issue/IssueForm.java
+++ b/src/main/java/com/example/its/web/issue/IssueForm.java
@@ -1,0 +1,9 @@
+package com.example.its.web.issue;
+
+import lombok.Data;
+
+@Data
+public class IssueForm {
+    private String summary;
+    private String description;
+}

--- a/src/main/resources/templates/issues/creationForm.html
+++ b/src/main/resources/templates/issues/creationForm.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>課題作成 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1>課題作成</h1>
+<form action="#" th:action="@{/issues}" th:method="post" th:object="${issueForm}">
+    <div>
+        <label for="summaryInput">概要</label>
+        <input type="text" id="summaryInput" th:field="*{summary}">
+    </div>
+    <div>
+        <label for="descriptionInput">説明</label>
+        <textarea id="descriptionInput" rows="10" th:field="*{description}"></textarea>
+    </div>
+    <div>
+        <button type="submit">作成</button>
+    </div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/issues/list.html
+++ b/src/main/resources/templates/issues/list.html
@@ -8,6 +8,7 @@
 <body>
 <h1>課題一覧</h1>
 <a href="../index.html" th:href="@{/}">トップページ</a>
+<a href="./creationForm.html" th:href="@{/issues/creationForm}">作成</a>
 <table>
     <thead>
     <tr>


### PR DESCRIPTION
### 🛠 やったこと
- フォームから送信されたデータをDBに保存する処理を実装
- `IssueRepository` を作成し、MyBatisで `insert` 処理を定義
- `IssueService` に `create()` メソッドを追加
- Controller に POST メソッド `create()` を実装
- HTMLテンプレートにフォームを追加（creationForm.html）

### 🧠 背景・目的
- ユーザーがWebフォームから課題情報を登録できるようにするため
- データを永続化し、一覧画面で表示できるようにするため

### ✅ 確認方法
- `http://localhost:8080/issues/creationForm` にアクセス
- フォームに入力後、「作成」ボタンを押して `issues` テーブルに保存されるか確認

### 💬 補足・メモ（あれば）
- DB接続やMyBatisのマッピングに問題がないことを事前に確認
- 登録後、リダイレクト先の一覧画面で入力した課題が表示されれば成功
