### PR TITLE
feat: バリデーションの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/its/domain/issue/IssueService.java
+++ b/src/main/java/com/example/its/domain/issue/IssueService.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 
 @Service

--- a/src/main/java/com/example/its/web/issue/IssueController.java
+++ b/src/main/java/com/example/its/web/issue/IssueController.java
@@ -4,6 +4,8 @@ import com.example.its.domain.issue.IssueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,8 +33,10 @@ public class IssueController {
     }
 
     @PostMapping
-    public String create(IssueForm form, Model model) {
-
+    public String create(@Validated IssueForm form, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            return showCreationForm(form);
+        }
         issueService.create(form.getSummary(), form.getDescription());
         return "redirect:/issues";
     }

--- a/src/main/java/com/example/its/web/issue/IssueForm.java
+++ b/src/main/java/com/example/its/web/issue/IssueForm.java
@@ -1,9 +1,18 @@
 package com.example.its.web.issue;
 
 import lombok.Data;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.NotBlank;
+
 
 @Data
 public class IssueForm {
+
+    @NotBlank
+    @Size(max=256)
     private String summary;
+
+    @NotBlank
+    @Size(max=256)
     private String description;
 }

--- a/src/main/resources/templates/issues/creationForm.html
+++ b/src/main/resources/templates/issues/creationForm.html
@@ -10,10 +10,12 @@
     <div>
         <label for="summaryInput">概要</label>
         <input type="text" id="summaryInput" th:field="*{summary}">
+        <p th:if="${#fields.hasErrors('summary')}" th:errors="*{summary}">(error)</p>
     </div>
     <div>
         <label for="descriptionInput">説明</label>
         <textarea id="descriptionInput" rows="10" th:field="*{description}"></textarea>
+        <p th:if="${#fields.hasErrors('description')}" th:errors="*{description}">(error)</p>
     </div>
     <div>
         <button type="submit">作成</button>


### PR DESCRIPTION
### 🛠 やったこと
- `IssueForm` にバリデーションアノテーション（@NotBlank, @Size）を追加
- `@Validated` と `BindingResult` を Controller に導入し、入力値を検証
- フォーム入力欄の下にエラーメッセージを表示する処理を追加
- `spring-boot-starter-validation` を `build.gradle` に追加

### 🧠 背景・目的
- 入力値の検証をサーバー側で行い、不正なデータの保存を防止するため
- ユーザーに適切なエラー表示を行い、入力ミスの修正を促すため

### ✅ 確認方法
- http://localhost:8080/issues/creationForm にアクセス
- フォームを空欄で送信し、summary/description にエラーメッセージが表示されることを確認

### 💬 補足・メモ
- 今後、エラーメッセージの日本語対応やUIの改善も検討中
