### PR TITLE
feat: 課題詳細画面のViewを実装

### DIFF
--- a/src/main/resources/templates/issues/detail.html
+++ b/src/main/resources/templates/issues/detail.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>課題詳細 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1>課題詳細</h1>
+<div>
+  <h2 th:text="${issue.summary}">(summary)</h2>
+  <p th:text="${issue.description}">(description)</p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
### 🛠 やったこと
- 課題詳細ページ（`detail.html`）を新規作成
- 課題のタイトル（summary）と内容（description）を表示
- Thymeleafの `th:text` を使ってデータバインドを実装

### 🧠 背景・目的
- 課題一覧から個別の課題詳細を確認できるようにするため
- 今後の編集機能追加に備えたビューの下地として

### ✅ 確認方法
- http://localhost:8080/issues/detail にアクセスし、課題のタイトルと説明が表示されることを確認

### 💬 補足・メモ（あれば）
- レイアウトは今後 Bootstrap を使って整える予定
