### PR TITLE
style: スタイリングとバリデーション実装

### DIFF
--- a/src/main/java/com/example/its/domain/issue/IssueRepository.java
+++ b/src/main/java/com/example/its/domain/issue/IssueRepository.java
@@ -14,4 +14,7 @@ public interface IssueRepository {
 
     @Insert("insert into issues (summary, description) values (#{summary}, #{description})")
     void insert(String summary, String description);
+
+    @Select("select * from issues where id = #{issueId}")
+    IssueEntity findById(long issueId);
 }

--- a/src/main/java/com/example/its/domain/issue/IssueService.java
+++ b/src/main/java/com/example/its/domain/issue/IssueService.java
@@ -20,4 +20,8 @@ public class IssueService {
     public void create(String summary, String description) {
         issueRepository.insert(summary, description);
     }
+
+    public IssueEntity findById(long issueId) {
+        return issueRepository.findById(issueId);
+    }
 }

--- a/src/main/java/com/example/its/web/issue/IssueController.java
+++ b/src/main/java/com/example/its/web/issue/IssueController.java
@@ -1,15 +1,13 @@
 package com.example.its.web.issue;
 
+import com.example.its.domain.issue.IssueEntity;
 import com.example.its.domain.issue.IssueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/issues")
@@ -39,5 +37,12 @@ public class IssueController {
         }
         issueService.create(form.getSummary(), form.getDescription());
         return "redirect:/issues";
+    }
+
+    @GetMapping("/{issueId}")
+    public String showDetail(@PathVariable("issueId") long issueId, Model model) {
+        var dummyEntity = new IssueEntity(1, "概要", "説明");
+        model.addAttribute("issue", issueService.findById(issueId));
+        return "issues/detail";
     }
 }

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!-- 【fragment定義】titleとcontentをパラメータで受け取る -->
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:fragment="layout(title, content)">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- 【fragmentインクルード】上にあるfragmentで受け取ったパラメータで置換する -->
+  <title th:replace="${title}">(default title)</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+</head>
+<body>
+<!-- 【fragmentインクルード】上にあるfragmentで受け取ったパラメータを挿入する -->
+<div class="container" th:insert="${content}"></div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
 <head>
-    <meta charset="UTF-8">
     <title>トップページ　｜　課題管理アプリケーション</title>
 </head>
 <body>
-<h1>課題管理アプリケーション</h1>
+<h1 class="mt-3">課題管理アプリケーション</h1>
 <ul>
     <li>
         <a href="./issues/list.html" th:href="@{/issues}">課題一覧</a>

--- a/src/main/resources/templates/issues/creationForm.html
+++ b/src/main/resources/templates/issues/creationForm.html
@@ -1,24 +1,25 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
 <head>
-    <meta charset="UTF-8">
     <title>課題作成 | 課題管理アプリケーション</title>
 </head>
 <body>
-<h1>課題作成</h1>
+<h1 class="mt-3">課題作成</h1>
 <form action="#" th:action="@{/issues}" th:method="post" th:object="${issueForm}">
-    <div>
-        <label for="summaryInput">概要</label>
-        <input type="text" id="summaryInput" th:field="*{summary}">
-        <p th:if="${#fields.hasErrors('summary')}" th:errors="*{summary}">(error)</p>
+    <div class="mt-3">
+        <label for="summaryInput" class="form-label">概要</label>
+        <input type="text" id="summaryInput" th:field="*{summary}" class="form-control" th:classappend="${#fields.hasErrors('summary')} ? is-invalid">
+        <p class="invalid-feedback" th:if="${#fields.hasErrors('summary')}" th:errors="*{summary}">(error)</p>
     </div>
-    <div>
-        <label for="descriptionInput">説明</label>
-        <textarea id="descriptionInput" rows="10" th:field="*{description}"></textarea>
-        <p th:if="${#fields.hasErrors('description')}" th:errors="*{description}">(error)</p>
+    <div class="mt-3">
+        <label for="descriptionInput" class="form-label">説明</label>
+        <textarea id="descriptionInput" rows="10" th:field="*{description}" class="form-control" th:classappend="${#fields.hasErrors('description')} ? is-invalid"></textarea>
+        <p class="invalid-feedback" th:if="${#fields.hasErrors('description')}" th:errors="*{description}">(error)</p>
     </div>
-    <div>
-        <button type="submit">作成</button>
+    <div class="mt-3">
+        <button type="submit" class="btn btn-primary">作成</button>
+        <a href="./list.html" th:href="@{/issues}" class="btn btn-secondary">キャンセル</a>
     </div>
 </form>
 </body>

--- a/src/main/resources/templates/issues/detail.html
+++ b/src/main/resources/templates/issues/detail.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
 <head>
-    <meta charset="UTF-8">
     <title>課題詳細 | 課題管理アプリケーション</title>
 </head>
 <body>
-<h1>課題詳細</h1>
+<h1 class="mt-3">課題詳細</h1>
+<a href="./list.html" th:href="@{/issues}">一覧に戻る</a>
 <div>
   <h2 th:text="${issue.summary}">(summary)</h2>
   <p th:text="${issue.description}">(description)</p>

--- a/src/main/resources/templates/issues/list.html
+++ b/src/main/resources/templates/issues/list.html
@@ -1,25 +1,28 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
-
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
 <head>
-    <meta charset="UTF-8">
     <title>課題一覧 | 課題管理アプリケーション</title>
 </head>
 <body>
-<h1>課題一覧</h1>
+<h1 class="mt-3">課題一覧</h1>
 <a href="../index.html" th:href="@{/}">トップページ</a>
 <a href="./creationForm.html" th:href="@{/issues/creationForm}">作成</a>
-<table>
+<table class="table">
     <thead>
     <tr>
         <th>#</th>
         <td>概要</td>
     </tr>
     </thead>
-    <tbody>
+    <tbody class="table-group-divider">
     <tr th:each="issue : ${issueList}">
         <th th:text="${issue.id}">(id)</th>
-        <td th:text="${issue.summary}">(summary)</td>
+        <td>
+            <a href="./detail.html" th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}">
+                (summary)
+            </a>
+        </td>
     </tr>
     </tbody>
 </table>


### PR DESCRIPTION
### 🛠 やったこと
- 入力フォームにバリデーション機能を追加
- エラー表示のスタイルを実装（赤枠やエラーメッセージ）
- Thymeleafのレイアウトテンプレートを導入（layout.html）
- 各ページ（index, list, detail, form）で共通レイアウトを適用
- 詳細ページ（detail）に課題内容を表示する機能を追加

### 🧠 背景・目的
- 入力エラー時にユーザーがどこを修正すべきか分かるようにするため
- ページ間で統一感のあるUIを提供するため
- 作成された課題の中身を確認できるようにするため

### ✅ 確認方法
- http://localhost:8080/issues/creationForm でフォーム入力・エラー表示を確認
- http://localhost:8080/issues にアクセスし、課題一覧とリンクが機能するか確認
- http://localhost:8080/issues/{id} で詳細ページが表示されるか確認

### 💬 補足・メモ
- Bootstrap 5 を導入済み（CDN経由）
- 今後、バリデーションルールやエラーメッセージ内容の改善も検討予定
