### PR TITLE
style: list.html内の文言「概要」を「課題」に変更

### DIFF
--- a/src/main/resources/templates/issues/list.html
+++ b/src/main/resources/templates/issues/list.html
@@ -11,8 +11,8 @@
 <table class="table">
     <thead>
     <tr>
-        <th>#</th>
-        <td>概要</td>
+        <th>No.</th>
+        <td>課題</td>
     </tr>
     </thead>
     <tbody class="table-group-divider">


### PR DESCRIPTION
### 🛠 やったこと
- 課題一覧ページ（list.html）内の表のヘッダー文言を「概要」から「課題」に変更

### 🧠 背景・目的
- 表示される内容が「概要」よりも「課題」という表現の方が適切と判断したため

### ✅ 確認方法
- http://localhost:8080/issues にアクセス
- テーブルヘッダーに「課題」と表示されていることを確認

### 💬 補足・メモ（あれば）
- UI上のラベル変更のみで、機能的な変更はありません
