### PR TITLE
feat: ログイン認証を実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/its/config/SecurityConfig.java
+++ b/src/main/java/com/example/its/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package com.example.its.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+//HTTPリクエストのセキュリティ設定を行うためのクラス
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//Spring SecurityのWebセキュリティ機能を有効化
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+//以下三つはユーザーの認証情報を管理するためのクラス
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+//パスワードの暗号化に使用されるエンコーダー
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//パスワードのエンコード処理を行うインターフェース
+import org.springframework.security.crypto.password.PasswordEncoder;
+//メモリ上にユーザー情報を保存するクラス
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+//HTTPセキュリティのフィルターチェーンを設定するクラス
+import org.springframework.security.web.SecurityFilterChain;
+
+//@Configurationは、Springの設定クラスであると示す。@Ena～はspring securityを有効化する
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    //メソッドがBean（オブジェクト）を生成することを示す
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/", "/home").permitAll() // ホームページは誰でもアクセス可能
+                        .anyRequest().authenticated() // その他のリクエストは認証が必要
+                )
+                .formLogin(login -> login.permitAll()
+                )
+                .logout(logout -> logout.permitAll()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.builder()
+                .username("user")
+                .password(passwordEncoder().encode("password"))
+                .roles("USER")
+                .build();
+
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+


### PR DESCRIPTION
### 🛠 やったこと
- Spring Security を導入し、基本的なログイン認証機能を実装
- SecurityFilterChain を設定して、"/" と "/home" のみ認証不要に
- インメモリユーザー（user/password）を作成し、認証対象に設定
- パスワードエンコーダーに BCrypt を使用

### 🧠 背景・目的
- ユーザーごとにアクセスを制御するためのログイン機能が必要だった
- 今後のユーザー管理機能の土台として認証を先に導入する目的

### ✅ 確認方法
- http://localhost:8080 にアクセス
- `user` / `password` でログインできることを確認
- `/` と `/home` は認証なしで表示されることを確認

### 💬 補足・メモ
- 今回は簡易的にインメモリ認証を使用
- 将来的にはDB連携やユーザー登録機能の追加を予定
