### PR TITLE
feat: 課題を戻すボタンと、jsで課題を戻す機能を実装

### DIFF
--- a/src/main/java/com/example/its/domain/issue/IssueRepository.java
+++ b/src/main/java/com/example/its/domain/issue/IssueRepository.java
@@ -19,7 +19,7 @@ public interface IssueRepository {
     List<IssueEntity> findAllCompletedIssues();
 
     // 課題IDに基づいて、その課題の完了状態をtrueに更新するクエリ
-    @Update("UPDATE issues SET is_completed = true WHERE id = #{issueId}")
+    @Update("UPDATE issues SET is_completed = CASE WHEN is_completed = true THEN false ELSE true END WHERE id = #{issueId}")
     void completeIssue(long issueId);
 
     // 指定されたIDの課題をデータベースから取得するクエリ

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,4 +7,4 @@ spring.datasource.password=springuser
 spring.sql.init.mode=always
 logging.level.com.example.its.repository=DEBUG
 spring.sql.init.encoding=UTF-8
-debug=true
+#logging.level.root=DEBUG

--- a/src/main/resources/static/js/completeIssue.js
+++ b/src/main/resources/static/js/completeIssue.js
@@ -1,0 +1,33 @@
+// JavaScriptを読み込む
+document.addEventListener("DOMContentLoaded", function() {
+    console.log("JavaScript loaded");
+
+    // CSRFトークンを取得取得する
+    const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+
+    // ボタンを取得する
+    const completeButtons = document.querySelectorAll(".complete-button");
+
+    completeButtons.forEach(function(button) {
+        // ボタンのクリックを検知
+        button.addEventListener("click", function(event) {
+            event.preventDefault();
+
+            // 課題IDを取得する
+            const issueId = this.getAttribute("data-issue-id");
+
+            const form = document.createElement("form");
+            form.method = "post";
+            form.action = "/issues/complete";
+
+            form.setAttribute("style", "display:none;");
+            form.innerHTML = `
+                <input type="hidden" name="id" value="${issueId}">
+                <input type="hidden" name="_csrf" value="${csrfToken}">
+            `;
+
+            document.body.appendChild(form);
+            form.submit();
+        });
+    });
+});

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -5,13 +5,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="_csrf" th:content="${_csrf.token}"/> <!-- CSRFトークンを設定 -->
+  <meta name="_csrf_header" th:content="${_csrf.headerName}"/> <!-- CSRFトークンのヘッダー名を設定 -->
   <!-- 【fragmentインクルード】上にあるfragmentで受け取ったパラメータで置換する -->
   <title th:replace="${title}">(default title)</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>
 <body>
 <!-- 【fragmentインクルード】上にあるfragmentで受け取ったパラメータを挿入する -->
-<div class="container" th:insert="${content}"></div>
+<div class="container px-5" th:insert="${content}"></div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/resources/templates/issues/list.html
+++ b/src/main/resources/templates/issues/list.html
@@ -5,48 +5,56 @@
     <title>課題一覧 | 課題管理アプリケーション</title>
 </head>
 <body>
-<h1 class="mt-3">課題一覧</h1>
-<a href="../index.html" th:href="@{/}">トップページ</a>
-<a href="./creationForm.html" th:href="@{/issues/creationForm}">作成</a>
-<form th:action="@{/issues/complete}" method="post">
-<table class="table">
-    <thead>
-    <tr>
-        <th>No.</th>
-        <td>課題</td>
-        <td>完了</td>
-    </tr>
-    </thead>
-    <tbody class="table-group-divider">
-    <!-- 課題リストをループして表示 -->
-    <tr th:each="issue : ${incompleteIssues}"> <!-- 未完了の課題リストをループ処理し、それぞれの課題を参照する -->
-        <th th:text="${issue.id}">(id)</th> <!-- 課題IDを表示する -->
-        <td>
-            <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
-        </td>
-        <td>
-            <input type="hidden" th:value="${issue.id}" name="id">
-            <button type="submit">完了</button> <!-- 完了ボタンを表示し、クリックで課題を完了状態にする -->
-        </td>
-    </tr>
-    </tbody>
-</table>
-</form>
+<div class="row px-5">
+    <div class="col px-5 mx-5">
+        <h1 class="mt-3">課題一覧</h1>
+        <div class="d-flex justify-content-end mt-2">
+            <a href="../index.html" th:href="@{/}" class="btn btn-success ms-2">トップページ</a>
+            <a href="./creationForm.html" th:href="@{/issues/creationForm}" class="btn btn-primary ms-2">作成</a>
+        </div>
 
-<h2 class="mt-5">完了した課題</h2>
-<table class="table">
-    <thead>
-    <tr>
-        <th>No.</th>
-        <td>課題</td>
-    </tr>
-    </thead>
-    <tbody class="table-group-divider">
-    <tr th:each="issue : ${completedIssues}"> <!-- 完了した課題リストをループ処理し、それぞれの課題を参照する -->
-        <th th:text="${issue.id}">(id)</th> <!-- 課題IDを表示する -->
-        <td th:text="${issue.summary}"></td> <!-- 完了した課題の概要を表示する -->
-    </tr>
-    </tbody>
-</table>
+        <!-- 未完了の課題 -->
+        <table class="table">
+            <thead>
+            <tr>
+                <td>課題</td>
+            </tr>
+            </thead>
+            <tbody class="table-group-divider">
+            <!-- 課題リストをループして表示 -->
+            <tr th:each="issue : ${incompleteIssues}"> <!-- 未完了の課題リストをループ処理し、それぞれの課題を参照する -->
+                <td class="align-middle">
+                    <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}" class="d-block w-100 text-start"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
+                </td>
+                <td class="align-middle text-end pe-5">
+                    <button type="button" class="complete-button btn btn-primary" th:data-issue-id="${issue.id}">完了</button> <!-- 完了ボタン、課題IDをdata属性に設定 -->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <!-- 完了した課題 -->
+        <h2 class="mt-5">完了した課題</h2>
+        <table class="table">
+            <thead>
+            <tr>
+                <td>課題</td>
+            </tr>
+            </thead>
+            <tbody class="table-group-divider">
+            <tr th:each="issue : ${completedIssues}"> <!-- 完了した課題リストをループ処理し、それぞれの課題を参照する -->
+                <td class="align-middle">
+                    <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}" class="d-block w-100 text-start"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
+                </td>
+                <td class="align-middle text-end pe-5">
+                    <button type="button" class="complete-button btn btn-outline-primary" th:data-issue-id="${issue.id}">戻す</button> <!-- 戻すボタン、課題IDをdata属性に設定 -->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<!-- JavaScriptファイルの読み込み -->
+<script src="/js/completeIssue.js"></script> <!-- JSファイルを読み込む -->
 </body>
 </html>


### PR DESCRIPTION
### 🛠 やったこと
- 未完了・完了済み課題の一覧表示レイアウトを大幅修正
  - `<form>` を除去し、ボタン押下で JS により POST 処理を行うよう変更
  - 未完了課題の「完了」ボタン、完了済み課題の「戻す」ボタンの設置
- `completeIssue.js` を修正し、課題を「完了」「未完了」に切り替えるJSロジックを整理
- layout.html に `csrf` メタタグを追加して、JavaScriptでのトークン取得を可能に
- テーブル構成を `未完了の課題` と `完了した課題` でそれぞれ分離して再設計
- 画面下部で JavaScript ファイルを読み込む構成に変更（`list.html`）

### 🧠 背景・目的
- 以前の構成は `<form>` によるサーバー送信とボタンの構造が複雑で、見通しが悪く、保守性が低かった
- 今後「非同期通信（Ajax）」への移行も視野に入れて、まずは `JavaScript + hidden form` による送信構造へ刷新
- 完了済み課題と未完了課題を明確に分けることで、ユーザーが課題の状態を一目で把握しやすくする
- 直感的に「完了」「戻す」の操作ができる UI を実現するため

### ✅ 確認方法
1. `http://localhost:8080/issues` にアクセス
2. 未完了課題が一覧で表示されていることを確認
3. 「完了」ボタンを押すと、課題が下部の「完了した課題」リストに移動することを確認
4. 「戻す」ボタンを押すと、再び未完了の一覧に戻ることを確認
5. すべての処理が POST で送信され、画面リロードによって状態が反映されること

### 💬 補足・メモ（あれば）
- 今後は JavaScript による非同期更新（fetch/Axios）にも対応予定
- トランザクション処理の整備・バリデーション追加も別 PR で対応予定
