### PR TITLE
feat: 課題の削除機能実装

### DIFF
--- a/src/main/java/com/example/its/config/SecurityConfig.java
+++ b/src/main/java/com/example/its/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 //Spring SecurityのWebセキュリティ機能を有効化
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 //以下三つはユーザーの認証情報を管理するためのクラス
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/example/its/domain/issue/IssueEntity.java
+++ b/src/main/java/com/example/its/domain/issue/IssueEntity.java
@@ -1,6 +1,5 @@
 package com.example.its.domain.issue;
 
-import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/src/main/java/com/example/its/domain/issue/IssueRepository.java
+++ b/src/main/java/com/example/its/domain/issue/IssueRepository.java
@@ -29,4 +29,8 @@ public interface IssueRepository {
     // 新しい課題の概要と説明をDBに新規挿入するクエリ
     @Insert("INSERT INTO issues (summary, description) VALUES (#{summary}, #{description})")
     void insert(String summary, String description);
+
+    // 課題IDに基づいて、その課題を削除するクエリ
+    @Update("DELETE FROM issues WHERE id = #{issueId}")
+    void delete(long issueId);
 }

--- a/src/main/java/com/example/its/domain/issue/IssueService.java
+++ b/src/main/java/com/example/its/domain/issue/IssueService.java
@@ -40,4 +40,10 @@ public class IssueService {
     public void insert(String summary, String description) {
         issueRepository.insert(summary, description);
     }
+
+    // 指定されたIDの課題を削除する
+    @Transactional
+    public void delete(Long id) {
+        issueRepository.delete(id);
+    }
 }

--- a/src/main/java/com/example/its/web/issue/IssueController.java
+++ b/src/main/java/com/example/its/web/issue/IssueController.java
@@ -49,4 +49,11 @@ public class IssueController {
         issueService.insert(form.getSummary(), form.getDescription());
         return "redirect:/issues"; // 課題一覧にリダイレクトする
     }
+
+    // 指定されたIDの課題を削除する
+    @PostMapping("/delete")
+    public String deleteIssue(@RequestParam Long id) {
+        issueService.delete(id);
+        return "redirect:/issues"; // 課題一覧にリダイレクトする
+    }
 }

--- a/src/main/resources/static/js/completeIssue.js
+++ b/src/main/resources/static/js/completeIssue.js
@@ -30,4 +30,30 @@ document.addEventListener("DOMContentLoaded", function() {
             form.submit();
         });
     });
+
+    // 削除ボタンを取得する
+    const deleteButtons = document.querySelectorAll(".delete-button");
+
+    deleteButtons.forEach(function(button) {
+        // 削除ボタンのクリックを検知
+        button.addEventListener("click", function(event) {
+            event.preventDefault();
+
+            // 課題IDを取得する
+            const issueId = this.getAttribute("data-issue-id");
+
+            const form = document.createElement("form");
+            form.method = "post";
+            form.action = "/issues/delete";
+
+            form.setAttribute("style", "display:none;");
+            form.innerHTML = `
+                <input type="hidden" name="id" value="${issueId}">
+                <input type="hidden" name="_csrf" value="${csrfToken}">
+            `;
+
+            document.body.appendChild(form);
+            form.submit();
+        });
+    });
 });

--- a/src/main/resources/templates/issues/list.html
+++ b/src/main/resources/templates/issues/list.html
@@ -24,10 +24,14 @@
             <!-- 課題リストをループして表示 -->
             <tr th:each="issue : ${incompleteIssues}"> <!-- 未完了の課題リストをループ処理し、それぞれの課題を参照する -->
                 <td class="align-middle">
-                    <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}" class="d-block w-100 text-start"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
+                    <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}"
+                       class="d-block w-100 text-start"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
                 </td>
                 <td class="align-middle text-end pe-5">
-                    <button type="button" class="complete-button btn btn-primary" th:data-issue-id="${issue.id}">完了</button> <!-- 完了ボタン、課題IDをdata属性に設定 -->
+                    <button type="button" class="complete-button btn btn-primary" th:data-issue-id="${issue.id}">
+                        完了</button> <!-- 完了ボタン、課題IDをdata属性に設定 -->
+                    <button type="button" class="delete-button btn btn-danger ms-2" th:data-issue-id="${issue.id}">
+                        削除</button> <!-- 削除ボタン、課題IDをdata属性に設定 -->
                 </td>
             </tr>
             </tbody>
@@ -44,10 +48,13 @@
             <tbody class="table-group-divider">
             <tr th:each="issue : ${completedIssues}"> <!-- 完了した課題リストをループ処理し、それぞれの課題を参照する -->
                 <td class="align-middle">
-                    <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}" class="d-block w-100 text-start"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
+                    <a th:href="@{/issues/{issueId}(issueId=${issue.id})}" th:text="${issue.summary}"
+                       class="d-block w-100 text-start"></a> <!-- 課題の概要をリンクとして表示し、詳細ページへのリンクを生成する -->
                 </td>
                 <td class="align-middle text-end pe-5">
-                    <button type="button" class="complete-button btn btn-outline-primary" th:data-issue-id="${issue.id}">戻す</button> <!-- 戻すボタン、課題IDをdata属性に設定 -->
+                    <button type="button" class="complete-button btn btn-outline-primary"
+                            th:data-issue-id="${issue.id}">戻す
+                    </button> <!-- 戻すボタン、課題IDをdata属性に設定 -->
                 </td>
             </tr>
             </tbody>
@@ -55,6 +62,6 @@
     </div>
 </div>
 <!-- JavaScriptファイルの読み込み -->
-<script src="/js/completeIssue.js"></script> <!-- JSファイルを読み込む -->
+<script src="/js/completeIssue.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### 🛠 やったこと
- 課題削除機能を実装
  - JavaScript による削除ボタンクリック時の POST リクエスト処理を追加（`completeIssue.js`）
  - `IssueController.java` に削除用のエンドポイント `/issues/delete` を追加
  - `IssueService.java` に `delete` メソッドを追加し、DB削除処理を `IssueRepository.java` に委譲
  - `IssueRepository.java` に `@Delete` クエリを追加
  - `IssueEntity.java` に `isCompleted` フラグを追加（削除と直接関係はしないが今回のコミットに含まれていた）
- 課題一覧 (`list.html`) に削除ボタンを表示し、削除処理と連携
- `script` タグで `completeIssue.js` を読み込み

### 🧠 背景・目的
- 課題の削除ができないと、運用上誤って作成したデータや不要な課題を取り除けず、ユーザーにとって不便な状態になるため
- まずは最小構成での削除機能を実装し、今後の改善（例：確認ダイアログの追加、非同期化など）に備える

### ✅ 確認方法
1. アプリケーションを起動（`docker-compose up -d`）
2. `http://localhost:8080/issues` にアクセス
3. 任意の課題の右側に表示される「削除」ボタンをクリック
4. 課題一覧から該当の課題が削除されていることを確認

### 💬 補足・メモ
- CSRF トークンの送信も JS 側で考慮済み（`_csrf` hidden input）
- `isCompleted` の追加は他 PRと関係する変更で、将来の状態管理の準備
